### PR TITLE
feat: runtime s3 config and base-path support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+AWS_REGION=
+AWS_S3_ENDPOINT=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+S3_BUCKET_NAME=
+
+# Base path for reverse proxy deployment (e.g., '/chemboard' for path-based routing)
+# Leave empty for root deployment
+BASE_PATH=""

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 set positional-arguments
+set dotenv-required
 set shell := ["bash", "-cue"]
 
 root_dir := `git rev-parse --show-toplevel`
@@ -13,6 +14,15 @@ alias fmt := format
 # Format the whole repository.
 format *args:
     treefmt {{args}}
+
+install:
+    pnpm install
+
+build: install
+    pnpm build
+
+run: build
+    node ./build/index.js
 
 alias dev := develop
 # Enter a Nix development shell.

--- a/src/lib/components/DisplayResults.svelte
+++ b/src/lib/components/DisplayResults.svelte
@@ -9,6 +9,7 @@
 	import type { S3FileInfo } from '$lib/schema/s3.js';
 	import { Pagination } from '@skeletonlabs/skeleton-svelte';
 	import type { ResultItemBase } from '$lib/schema/campaign';
+	import { base } from '$app/paths';
 
 	// get props from data loader
 	let {
@@ -33,7 +34,7 @@
         detailedContent = null;
         try {
             // Adjust the URL to your actual API endpoint structure
-            const response = await fetch(`/api/${path}`);
+            const response = await fetch(`${base}/api/${path}`);
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({ message: `HTTP error! status: ${response.status}` }));
                 throw new Error(errorData.message || `Failed to fetch details. Status: ${response.status}`);

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
+	import { base } from '$app/paths';
 	import Paperclip from '@lucide/svelte/icons/paperclip';
 	import Calendar from '@lucide/svelte/icons/calendar';
 	import Home from '@lucide/svelte/icons/home';
@@ -10,9 +11,9 @@
 
 <AppBar classes="flex items-left">
 	{#snippet lead()}
-	    <a href="/" class="flex items-center mx-4 gap-x-2"><Home size={20} />Home</a>
-	    <a href="/search" class="flex items-center mx-4 gap-x-2"><Search size={20} />Search</a>
-		<a href="/batch" class="flex items-center mx-4 gap-x-2"><Database size={20} />Data</a>
+	    <a href="{base}/" class="flex items-center mx-4 gap-x-2"><Home size={20} />Home</a>
+	    <a href="{base}/search" class="flex items-center mx-4 gap-x-2"><Search size={20} />Search</a>
+		<a href="{base}/batch" class="flex items-center mx-4 gap-x-2"><Database size={20} />Data</a>
 	{/snippet}
 	{#snippet trail()}
 		<Paperclip size={20} />

--- a/src/lib/config/environment.ts
+++ b/src/lib/config/environment.ts
@@ -1,0 +1,58 @@
+// Environment configuration for AWS S3 access
+// This file provides a consistent interface for environment variables
+// that works during both build time and runtime
+
+import { dev } from '$app/environment';
+
+// Try to import from SvelteKit's env modules, with fallbacks for build time
+let awsRegion = '';
+let awsAccessKeyId = '';
+let awsSecretAccessKey = '';
+let s3BucketName = '';
+let awsS3Endpoint = '';
+
+// Dynamic import that won't fail during build
+try {
+  // This will only work at runtime
+  const { AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET_NAME, AWS_S3_ENDPOINT } = 
+    process.env.NODE_ENV === 'production' 
+      ? process.env // In production, read directly from process.env
+      : await import('$env/dynamic/private'); // In dev, use SvelteKit's env system
+  
+  awsRegion = AWS_REGION || '';
+  awsAccessKeyId = AWS_ACCESS_KEY_ID || '';
+  awsSecretAccessKey = AWS_SECRET_ACCESS_KEY || '';
+  s3BucketName = S3_BUCKET_NAME || '';
+  awsS3Endpoint = AWS_S3_ENDPOINT || '';
+} catch (error) {
+  if (dev) {
+    console.warn('Running in build mode or environment variables not available:', error);
+  }
+  // During build, we'll use empty strings, which will be replaced at runtime
+}
+
+// Export the environment variables
+export const AWS_REGION = awsRegion;
+export const AWS_ACCESS_KEY_ID = awsAccessKeyId;
+export const AWS_SECRET_ACCESS_KEY = awsSecretAccessKey;
+export const S3_BUCKET_NAME = s3BucketName;
+export const AWS_S3_ENDPOINT = awsS3Endpoint;
+
+// Helper functions for validation
+export function isS3Configured(): boolean {
+  return Boolean(AWS_REGION && S3_BUCKET_NAME);
+}
+
+export function hasS3Credentials(): boolean {
+  return Boolean(AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY);
+}
+
+export function validateS3Config(): void {
+  if (!AWS_REGION) {
+    throw new Error('Missing required environment variable: AWS_REGION');
+  }
+  
+  if (!S3_BUCKET_NAME) {
+    throw new Error('Missing required environment variable: S3_BUCKET_NAME');
+  }
+}

--- a/src/lib/config/environment.ts
+++ b/src/lib/config/environment.ts
@@ -4,34 +4,22 @@
 
 import { dev } from '$app/environment';
 
-// Try to import from SvelteKit's env modules, with fallbacks for build time
-let awsRegion = '';
-let awsAccessKeyId = '';
-let awsSecretAccessKey = '';
-let s3BucketName = '';
-let awsS3Endpoint = '';
-
-// Dynamic import that won't fail during build
-try {
-  // This will only work at runtime
-  const { AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET_NAME, AWS_S3_ENDPOINT } = 
-    process.env.NODE_ENV === 'production' 
-      ? process.env // In production, read directly from process.env
-      : await import('$env/dynamic/private'); // In dev, use SvelteKit's env system
-  
-  awsRegion = AWS_REGION || '';
-  awsAccessKeyId = AWS_ACCESS_KEY_ID || '';
-  awsSecretAccessKey = AWS_SECRET_ACCESS_KEY || '';
-  s3BucketName = S3_BUCKET_NAME || '';
-  awsS3Endpoint = AWS_S3_ENDPOINT || '';
-} catch (error) {
-  if (dev) {
-    console.warn('Running in build mode or environment variables not available:', error);
+// Simple environment variable loading that works in both dev and production
+function getEnvVar(name: string): string {
+  // In production builds, always use process.env
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[name] || '';
   }
-  // During build, we'll use empty strings, which will be replaced at runtime
+  return '';
 }
 
 // Export the environment variables
+const awsRegion = getEnvVar('AWS_REGION');
+const awsAccessKeyId = getEnvVar('AWS_ACCESS_KEY_ID');
+const awsSecretAccessKey = getEnvVar('AWS_SECRET_ACCESS_KEY');
+const s3BucketName = getEnvVar('S3_BUCKET_NAME');
+const awsS3Endpoint = getEnvVar('AWS_S3_ENDPOINT');
+
 export const AWS_REGION = awsRegion;
 export const AWS_ACCESS_KEY_ID = awsAccessKeyId;
 export const AWS_SECRET_ACCESS_KEY = awsSecretAccessKey;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ContentLayout from '$lib/components/ContentLayout.svelte';
+    import { base } from '$app/paths';
 </script>
 
 {#snippet sidebar()}
@@ -26,9 +27,9 @@
 
 {#snippet main()}
 	<h1 class="mb-6 p-4 text-2xl font-bold text-gray-800">An automated Catalysis Lab</h1>
-	<h2 class="mb-6 p-4 text-xl font-bold"><a href="/batch" class="text-primary-500">Exlore the data</a></h2>
+	<h2 class="mb-6 p-4 text-xl font-bold"><a href="{base}/batch" class="text-primary-500">Exlore the data</a></h2>
 	<p>Explore the campaigns by year / month / day</p>
-	<h2 class="mb-6 p-4 text-xl font-bold"><a href="/search" class="text-primary-500">Search in the Campaigns</a></h2>
+	<h2 class="mb-6 p-4 text-xl font-bold"><a href="{base}/search" class="text-primary-500">Search in the Campaigns</a></h2>
 	<p>You can search Campaigns by a variety of search criteria:</p>
 	<ul class="mb-6 p-4 list-disc">
 		<li>Campaign Name</li>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -16,7 +16,13 @@ const config = {
 				host: '0.0.0.0',
 				port: '3000'
 			}
-		})
+		}),
+		// Support for base path when deployed behind reverse proxy
+		// Set BASE_PATH environment variable (e.g., '/chemboard') for path-based routing
+		paths: {
+			base: process.env.BASE_PATH || ''
+			// assets path omitted - will use same path as base for relative assets
+		}
 	}
 };
 

--- a/tools/deploy/schema.yaml
+++ b/tools/deploy/schema.yaml
@@ -26,6 +26,11 @@ s3:
 service:
   port: 80
 
+app:
+  #@schema/desc "Base path for reverse proxy deployment (e.g., '/chemboard' for path-based routing). Leave empty for root deployment."
+  #@schema/example "/chemboard"
+  basePath: ""
+
 ingress:
   #@schema/desc "Whether to create an Ingress resource"
   enabled: true

--- a/tools/deploy/templates/configmap.yaml
+++ b/tools/deploy/templates/configmap.yaml
@@ -12,3 +12,4 @@ data:
   NODE_ENV: 'production'
   PORT: '3000'
   HOST: '0.0.0.0'
+  BASE_PATH: #@ data.values.app.basePath

--- a/tools/deploy/templates/deployment.yaml
+++ b/tools/deploy/templates/deployment.yaml
@@ -38,6 +38,11 @@ spec:
             configMapKeyRef:
               name: #@ data.values.name + "-config"
               key: HOST
+        - name: BASE_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: #@ data.values.name + "-config"
+              key: BASE_PATH
         - name: AWS_REGION
           valueFrom:
             secretKeyRef:
@@ -66,13 +71,13 @@ spec:
 
         readinessProbe:
           httpGet:
-            path: /
+            path: #@ data.values.app.basePath + "/"
             port: http
           initialDelaySeconds: 10
           periodSeconds: 5
         livenessProbe:
           httpGet:
-            path: /
+            path: #@ data.values.app.basePath + "/"
             port: http
           initialDelaySeconds: 20
           periodSeconds: 10

--- a/tools/image/Dockerfile
+++ b/tools/image/Dockerfile
@@ -1,6 +1,9 @@
 # Build stage
 FROM node:20-alpine AS build
 
+ENV NODE_ENV=production
+ENV PORT=3000
+
 # Install pnpm
 RUN npm install -g pnpm
 
@@ -15,13 +18,6 @@ RUN pnpm install
 
 # Copy the rest of the source code
 COPY . .
-
-# Create a placeholder .env file with dummy values for build time
-RUN echo "AWS_REGION=us-east-1" > .env && \
-    echo "AWS_ACCESS_KEY_ID=placeholder" >> .env && \
-    echo "AWS_SECRET_ACCESS_KEY=placeholder" >> .env && \
-    echo "S3_BUCKET_NAME=placeholder" >> .env && \
-    echo "AWS_S3_ENDPOINT=https://placeholder.example.com" >> .env
 
 # Build the application
 RUN pnpm build
@@ -40,10 +36,17 @@ COPY --from=build /app/node_modules ./node_modules
 # Expose the port the app will run on
 EXPOSE 3000
 
-# Environment variables
+# Application settings
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
+
+# AWS/S3 Configuration - these can be overridden at runtime
+ENV AWS_REGION=""
+ENV AWS_ACCESS_KEY_ID=""
+ENV AWS_SECRET_ACCESS_KEY=""
+ENV S3_BUCKET_NAME=""
+ENV AWS_S3_ENDPOINT=""
 
 # Command to run the application
 CMD ["node", "build/index.js"]

--- a/tools/image/Dockerfile
+++ b/tools/image/Dockerfile
@@ -48,5 +48,8 @@ ENV AWS_SECRET_ACCESS_KEY=""
 ENV S3_BUCKET_NAME=""
 ENV AWS_S3_ENDPOINT=""
 
+# Base path for reverse proxy deployment (e.g., '/chemboard' for path-based routing)
+ENV BASE_PATH=""
+
 # Command to run the application
 CMD ["node", "build/index.js"]


### PR DESCRIPTION
This PR allows to build the svelte bundle without exporting environment variables for the S3 setup.
It allows to build the docker image without embedding sensitive information (S3 credentials) in the bundle, and then defining these variables at runtime.